### PR TITLE
add namespace header to fix compiler error

### DIFF
--- a/src-ble/windows/NativeBleInternal.cpp
+++ b/src-ble/windows/NativeBleInternal.cpp
@@ -4,6 +4,7 @@
 #include "winrt/Windows.Devices.Bluetooth.Advertisement.h"
 #include "winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h"
 #include "winrt/Windows.Foundation.h"
+#include "winrt/Windows.Foundation.Collections.h"
 #include "winrt/Windows.Storage.Streams.h"
 #include "winrt/base.h"
 


### PR DESCRIPTION
Background to this fix can be found here: https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c3779?f1url=%3FappId%3DDev16IDEF1%26l%3DDE-DE%26k%3Dk(C3779)%26rd%3Dtrue&view=msvc-160